### PR TITLE
#82065 signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ class ConsumeMessageJob implements ShouldQueue
 
 ```
 
+### Handling signals
+
+`php artisan kafka:consume ...` command can be configured to gracefully stop after receiving some OS signals.  
+Such signals can be set in the `stop_signals` key of the package config, e.g `'stop_signals' => [SIGINT, SIGQUIT]`.  
+You can use any of the constants defined by the pcntl extension https://www.php.net/manual/en/pcntl.constants.php  
+
 ## Testing
 
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,10 @@
         "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     },
     "extra": {
         "laravel": {

--- a/src/HighLevelConsumer.php
+++ b/src/HighLevelConsumer.php
@@ -14,6 +14,8 @@ class HighLevelConsumer
 {
     protected ?KafkaConsumer $consumer;
 
+    protected $forceStop = false;
+
     public function __construct(
         protected KafkaManager $kafkaManager,
         protected Pipeline $pipeline
@@ -25,6 +27,13 @@ class HighLevelConsumer
         $this->consumer = is_null($consumerName)
             ? $this->kafkaManager->consumer()
             : $this->kafkaManager->consumer($consumerName);
+
+        return $this;
+    }
+
+    public function forceStop(): static
+    {
+        $this->forceStop = true;
 
         return $this;
     }
@@ -115,6 +124,6 @@ class HighLevelConsumer
             return true;
         }
 
-        return false;
+        return $this->forceStop;
     }
 }


### PR DESCRIPTION
Если послать kill -{номер сигнала} {pid} не указанный в конфиге то процесс умирает штатно по этому сигналу, что может быть печально когда он на половину обработал сообщение из топика.

![image](https://user-images.githubusercontent.com/2826480/149165354-f6fc6cb5-54f1-44ab-bc86-81530f257a2c.png)

После доработки мы можем сконфигурировать команду чтобы она слушала выбранные сигналы по-другому - текущее сообщение будет прочитано до конца, а вот следующее консумер читать не пойдет, а выйдет из while() и команда штатно завершит свою работу

![image](https://user-images.githubusercontent.com/2826480/149165878-e843e44b-540d-454a-afbe-aa631e9c354d.png)

