### PR TITLE
DEVOPS-2512 feature: listen multiple topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ use Ensi\LaravelPhpRdKafkaConsumer\Commands\KafkaConsumeCommand;
 use Ensi\LaravelPhpRdKafkaConsumer\Tests\ConsumerFaker;
 use RdKafka\Message;
 
-ConsumerFaker::new('test-model')
+ConsumerFaker::new(['test-model'])
     ->addMessage(new Message())
     ->addMessage(new Message())
     ->consume();

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,20 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true"
->
-    <testsuites>
-        <testsuite name="Tests">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <coverage>
-        <include>
-            <directory suffix="Test.php">./src</directory>
-        </include>
-    </coverage>
-    <logging>
-        <junit outputFile="build/report.junit.xml"/>
-    </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
+  <testsuites>
+    <testsuite name="Tests">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <junit outputFile="build/report.junit.xml"/>
+  </logging>
+  <source>
+    <include>
+      <directory suffix="Test.php">./src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Consumers/Consumer.php
+++ b/src/Consumers/Consumer.php
@@ -5,22 +5,28 @@ namespace Ensi\LaravelPhpRdKafkaConsumer\Consumers;
 use Ensi\LaravelPhpRdKafkaConsumer\ConsumerOptions;
 use Ensi\LaravelPhpRdKafkaConsumer\HighLevelConsumer;
 use Ensi\LaravelPhpRdKafkaConsumer\ProcessorData;
-use RdKafka\Exception;
 use Throwable;
 
 class Consumer
 {
+    /**
+     * @param HighLevelConsumer $highLevelConsumer
+     * @param ProcessorData[] $processorData
+     * @param ConsumerOptions $consumerOptions
+     * @param array $topicNames
+     */
     public function __construct(
         protected HighLevelConsumer $highLevelConsumer,
-        protected ProcessorData $processorData,
+        protected array $processorData,
         protected ConsumerOptions $consumerOptions,
-        protected string $topicName
+        protected array $topicNames,
+        protected string $consumerName,
     ) {
     }
 
-    public function getTopicName(): string
+    public function getTopicNames(): array
     {
-        return $this->topicName;
+        return $this->topicNames;
     }
 
     public function setMaxTime(int $maxTime = 0): self
@@ -42,24 +48,18 @@ class Consumer
         $this->highLevelConsumer->forceStop();
     }
 
-    public function getProcessorData(): ProcessorData
-    {
-        return $this->processorData;
-    }
-
     public function getConsumerOptions(): ConsumerOptions
     {
         return $this->consumerOptions;
     }
 
     /**
-     * @throws Exception
      * @throws Throwable
      */
     public function listen(): void
     {
         $this->highLevelConsumer
-            ->for($this->processorData->consumer)
-            ->listen($this->topicName, $this->processorData, $this->consumerOptions);
+            ->for($this->consumerName)
+            ->listen($this->topicNames, $this->processorData, $this->consumerOptions);
     }
 }

--- a/src/Tests/Consumer/KafkaConsumer.php
+++ b/src/Tests/Consumer/KafkaConsumer.php
@@ -12,11 +12,11 @@ class KafkaConsumer extends BaseKafkaConsumer
 {
     protected Metadata $metadata;
 
-    public function __construct(string $topicName, protected array $messages = [])
+    public function __construct(array $topicNames, protected array $messages = [])
     {
         parent::__construct($this->makeConf());
 
-        $this->metadata = new Metadata($topicName);
+        $this->metadata = new Metadata($topicNames);
     }
 
     private function makeConf(): Conf
@@ -42,7 +42,7 @@ class KafkaConsumer extends BaseKafkaConsumer
     /**
      * @phpstan-ignore-next-line
      */
-    public function getMetadata($all_topics, $only_topic = null, $timeout_ms): Metadata
+    public function getMetadata($all_topics, $only_topic = null, $timeout_ms = 0): Metadata
     {
         return $this->metadata;
     }

--- a/src/Tests/Consumer/Topics/Metadata.php
+++ b/src/Tests/Consumer/Topics/Metadata.php
@@ -2,13 +2,15 @@
 
 namespace Ensi\LaravelPhpRdKafkaConsumer\Tests\Consumer\Topics;
 
+use Illuminate\Support\Arr;
+
 class Metadata
 {
     protected array $topics = [];
 
-    public function __construct(string $topicName)
+    public function __construct(array $topicNames)
     {
-        $this->topics[] = new Topic($topicName);
+        $this->topics = Arr::map($topicNames, fn ($topicName) => new Topic($topicName));
     }
 
     public function getTopics(): array

--- a/tests/Commands/KafkaConsumerCommandTest.php
+++ b/tests/Commands/KafkaConsumerCommandTest.php
@@ -3,9 +3,11 @@
 use Ensi\LaravelPhpRdKafkaConsumer\Commands\KafkaConsumeCommand;
 use Ensi\LaravelPhpRdKafkaConsumer\Tests\ConsumerFaker;
 use Ensi\LaravelPhpRdKafkaConsumer\Tests\TestConsumer;
-use RdKafka\Message;
+
 use function Pest\Laravel\artisan;
 use function PHPUnit\Framework\assertContains;
+
+use RdKafka\Message;
 
 test('consume command test', function () {
     TestConsumer::fake('test-model');

--- a/tests/Commands/KafkaConsumerCommandTest.php
+++ b/tests/Commands/KafkaConsumerCommandTest.php
@@ -3,21 +3,56 @@
 use Ensi\LaravelPhpRdKafkaConsumer\Commands\KafkaConsumeCommand;
 use Ensi\LaravelPhpRdKafkaConsumer\Tests\ConsumerFaker;
 use Ensi\LaravelPhpRdKafkaConsumer\Tests\TestConsumer;
-
-use function Pest\Laravel\artisan;
-
 use RdKafka\Message;
+use function Pest\Laravel\artisan;
+use function PHPUnit\Framework\assertContains;
 
 test('consume command test', function () {
     TestConsumer::fake('test-model');
+    $message = new Message();
+    $message->topic_name = 'production.test.fact.test-model.1';
 
-    ConsumerFaker::new('test-model')
-        ->addMessage($message = new Message())
+    ConsumerFaker::new(['test-model'])
+        ->addMessage($message)
         ->bind();
 
     artisan(KafkaConsumeCommand::class, ['topic-key' => 'test-model'])
-        ->expectsOutputToContain('Start listening to topic: "test-model" (production.test.fact.test-model.1), consumer "default"')
+        ->expectsOutputToContain('Start listening to topic: production.test.fact.test-model.1, consumer "default"')
         ->assertOk();
 
     TestConsumer::assertMessageConsumed($message);
+});
+
+test('consume command test listen multiple topics', function () {
+    app()->scoped('processor-1', fn () => new TestConsumer());
+    app()->scoped('processor-2', fn () => new TestConsumer());
+
+    config()->set('kafka-consumer.processors', [
+        ['topic' => 'topic-1', 'class' => 'processor-1', 'type' => 'action'],
+        ['topic' => 'topic-2', 'class' => 'processor-2', 'type' => 'action'],
+    ]);
+
+    config()->set('kafka.connections.default.topics', [
+        'topic-1' => "production.test.fact.topic-1.1",
+        'topic-2' => "production.test.fact.topic-2.1",
+    ]);
+
+    $message1 = new Message();
+    $message1->topic_name = 'production.test.fact.topic-1.1';
+
+    $message2 = new Message();
+    $message2->topic_name = 'production.test.fact.topic-2.1';
+
+    ConsumerFaker::new(['topic-1', 'topic-2'])
+        ->addMessage($message1)
+        ->addMessage($message2)
+        ->bind();
+
+    artisan(KafkaConsumeCommand::class, ['topic-key' => 'topic-1,topic-2'])
+        ->expectsOutputToContain('Start listening to topic: production.test.fact.topic-1.1, consumer "default"')
+        ->expectsOutputToContain('Start listening to topic: production.test.fact.topic-2.1, consumer "default"')
+        ->assertOk();
+
+    assertContains($message1, resolve('processor-1')->messages);
+    assertContains($message2, resolve('processor-2')->messages);
 });

--- a/tests/ConsumerFakerTest.php
+++ b/tests/ConsumerFakerTest.php
@@ -8,8 +8,11 @@ use RdKafka\Message;
 test('create and consume kafka manager fake', function () {
     TestConsumer::fake('test-model');
 
-    ConsumerFaker::new('test-model')
-        ->addMessage($message = new Message())
+    $message = new Message();
+    $message->topic_name = 'production.test.fact.test-model.1';
+
+    ConsumerFaker::new(['test-model'])
+        ->addMessage($message)
         ->consume();
 
     TestConsumer::assertMessageConsumed($message);
@@ -18,8 +21,11 @@ test('create and consume kafka manager fake', function () {
 test('bind testing kafka manager with faker consumer', function () {
     TestConsumer::fake('test-model');
 
-    ConsumerFaker::new('test-model')
-        ->addMessage(new Message())
+    $message = new Message();
+    $message->topic_name = 'production.test.fact.test-model.1';
+
+    ConsumerFaker::new(['test-model'])
+        ->addMessage($message)
         ->bind();
 
     expect(resolve(KafkaManager::class))

--- a/tests/Consumers/ConsumerTest.php
+++ b/tests/Consumers/ConsumerTest.php
@@ -22,9 +22,10 @@ test('consumer listen', function () {
 
     $consumer = new Consumer(
         highLevelConsumer: $highLevelConsumer,
-        processorData: $processorData,
+        processorData: [$processorData],
         consumerOptions: $consumerOptions,
-        topicName: 'production.domain.fact.models.1'
+        topicNames: ['production.domain.fact.models.1'],
+        consumerName: 'default',
     );
 
     $consumer
@@ -39,5 +40,5 @@ test('consumer listen', function () {
         ->toBe(5100);
 
     $highLevelConsumer->shouldHaveReceived('for', ['default']);
-    $highLevelConsumer->shouldHaveReceived('listen', ['production.domain.fact.models.1', $processorData, $consumerOptions]);
+    $highLevelConsumer->shouldHaveReceived('listen', [['production.domain.fact.models.1'], [$processorData], $consumerOptions]);
 });

--- a/tests/Consumers/Factories/ConsumerFactoryTest.php
+++ b/tests/Consumers/Factories/ConsumerFactoryTest.php
@@ -7,21 +7,14 @@ use Ensi\LaravelPhpRdKafkaConsumer\Tests\TestConsumer;
 
 test('get exception when topic key config not found', function () {
     (new ConsumerFactory(resolve(HighLevelConsumer::class)))
-        ->build('not-found-topic-key');
-})->throws(KafkaConsumerProcessorException::class, 'Processor for topic-key "not-found-topic-key" and consumer "default" is not found');
-
-test('get exception when processor class not found', function () {
-    setConsumerTopicConfig('test-models', 'NotFoundConsumerClass');
-
-    (new ConsumerFactory(resolve(HighLevelConsumer::class)))
-        ->build('test-models');
-})->throws(KafkaConsumerProcessorException::class, 'Processor class "NotFoundConsumerClass" is not found');
+        ->build(['not-found-topic-key']);
+})->throws(InvalidArgumentException::class, "Topic with key 'not-found-topic-key' is not registered in kafka.topics");
 
 test('get exception when processor invalid type', function () {
     setConsumerTopicConfig('test-models', TestConsumer::class, 'invalid-type');
 
     (new ConsumerFactory(resolve(HighLevelConsumer::class)))
-        ->build('test-models');
+        ->build(['test-models']);
 })->throws(KafkaConsumerProcessorException::class, 'Invalid processor type "invalid-type", supported types are: action,job');
 
 test('set consume_timeout and middleware to consumer options', function () {
@@ -37,7 +30,7 @@ test('set consume_timeout and middleware to consumer options', function () {
     setConsumerTopicConfig('test-models', TestConsumer::class);
 
     $consumer = (new ConsumerFactory(resolve(HighLevelConsumer::class)))
-        ->build('test-models');
+        ->build(['test-models']);
 
     $consumerOptions = $consumer->getConsumerOptions();
 


### PR DESCRIPTION
Now you can pass many topic keys to `kafka:consume` command
Example:
```
php artisan kafka:consume offers,stocks,brands
```